### PR TITLE
chore: RID-12099 - prepare for npm v12: drop always-auth via setup-node v6

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,10 +18,9 @@ jobs:
 
     steps:
       - name: Use Node.js v${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
-          always-auth: true
 
       - name: Checkout
         uses: actions/checkout@v3
@@ -67,11 +66,10 @@ jobs:
 
     steps:
       - name: Use Node.js v${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           registry-url: "https://npm.pkg.github.com"
-          always-auth: true
 
       - name: Fetch cached workspace
         uses: actions/cache@v3
@@ -107,11 +105,10 @@ jobs:
 
     steps:
       - name: Use Node.js v${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           registry-url: "https://registry.npmjs.org"
-          always-auth: true
 
       - name: Fetch cached workspace
         uses: actions/cache@v3


### PR DESCRIPTION
setup-node@v3's always-auth input unconditionally writes a bare, unscoped always-auth=<value> line to .npmrc whenever registry-url is set, regardless of the input's value. npm >=11.16 rejects always-auth in any form (removed in npm v12). setup-node@v6 dropped the always-auth input and its .npmrc writing entirely -- confirmed against its source, the registry-url/_authToken/ NODE_AUTH_TOKEN mechanism this workflow relies on is otherwise unchanged. The build job's setup-node call had always-auth: true but no registry-url, so it was already a no-op; removed for consistency with the other two calls in this file. ci.yml doesn't set registry-url or always-auth anywhere, so it isn't affected and is left untouched.